### PR TITLE
Include RSS link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
     <title> {{ page.title }}</title>
+    <link rel="alternate" type="application/rss+xml" title="Todal I learned: Vim RSS Feed" href="/feed.xml" />
   </head>
   <body>
     <a href="https://github.com/jackfranklin/tilvim"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>


### PR DESCRIPTION
With this, the RSS feed can be auto-discovered using standard methods. Some feed readers may scrape the page and try guessing the link to the feed, or they could be pointed to the correct location in the first place.
